### PR TITLE
분할 터널 설정으로 vpc cidr 외의 다른 네트워크 접근은 vpn으로 향하지 않도록 설정

### DIFF
--- a/vpc-config/_modules/client_vpn/main.tf
+++ b/vpc-config/_modules/client_vpn/main.tf
@@ -10,6 +10,7 @@ resource "aws_ec2_client_vpn_endpoint" "this" {
     root_certificate_chain_arn = var.client_certificate_arn
   }
 
+  split_tunnel = true
   # 연결 로깅
   connection_log_options {
     enabled = false

--- a/vpc-config/prod/main.tf
+++ b/vpc-config/prod/main.tf
@@ -38,12 +38,3 @@ resource "aws_ec2_client_vpn_network_association" "this" {
   client_vpn_endpoint_id = module.client_vpn.client_vpn_endpoint_id
   subnet_id              = each.value
 }
-
-# 라우팅 테이블 설정
-# 추후 CIDR을 az별로 나누어 설정할 수 있도록 변경 필요
-resource "aws_ec2_client_vpn_route" "this" {
-
-  client_vpn_endpoint_id = module.client_vpn.client_vpn_endpoint_id
-  destination_cidr_block = data.aws_vpc.this.cidr_block
-  target_vpc_subnet_id   = local.core_subnets_outputs.private_subnet_ids[0]
-}


### PR DESCRIPTION
aws_ec2_client_vpn_authorization_rule 생성시 이미 해당 cidr에 대해서는 aws_ec2_client_vpn_route이 기본값으로 생성되는 것으로 보인다 따라서 aws_ec2_client_vpn_route 코드 제거